### PR TITLE
 Make it possible to run landiscover without root & without args

### DIFF
--- a/main.go
+++ b/main.go
@@ -89,10 +89,6 @@ func newProgram() error {
 		kong.Description("landiscover "+version),
 		kong.UsageOnError())
 
-	if os.Getuid() != 0 {
-		return fmt.Errorf("you must be root")
-	}
-
 	layerNbnsInit()
 	layerMdnsInit()
 
@@ -159,6 +155,7 @@ func newProgram() error {
 
 	err = newListener(p)
 	if err != nil {
+		fmt.Printf("Couldn't start listener, please check permissions. You must either run this program as 'root', or - more recommended - add the 'CAP_NET_RAW' capability to the executable: sudo setcap cap_net_raw+ep %s\n", os.Args[0])
 		return err
 	}
 

--- a/main.go
+++ b/main.go
@@ -81,7 +81,7 @@ type program struct {
 
 var cli struct {
 	Passive   bool   `help:"do not send any packet."`
-	Interface string `arg:"" help:"Interface to listen to."`
+	Interface string `arg:"" optional:"" help:"Interface to listen to."`
 }
 
 func newProgram() error {


### PR DESCRIPTION
- Make it possible to run landiscover without root, and suggest to add the CAP_NET_RAW capability to do so if the listener couldn't be started
- Make interface optional as it is automatically detected in that case

<img width="1699" height="64" alt="grafik" src="https://github.com/user-attachments/assets/abbc4795-c9db-4e6b-a45d-ca66b451e18f" />
